### PR TITLE
Add support for work and personal environments in SSH and GPG configurations

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 André Silva
+Copyright (c) André Silva
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ To switch back to personal:
 rm ~/.work
 ```
 
+Package installs follow the same split in `home/.chezmoidata/packages.yaml`:
+
+- `common` is always installed.
+- `personal` is installed when `personal: true`.
+- `work` is installed when `work: true`.
+
 ## Thanks To
 
 I want to thank all the people that worked on the following repositories:

--- a/home/.chezmoi.yaml.tmpl
+++ b/home/.chezmoi.yaml.tmpl
@@ -13,7 +13,7 @@
 {{- $name := "André Silva" -}}
 {{- $email := "2493377+askpt@users.noreply.github.com" -}}
 {{- if and $work (not $codespaces) -}}
-{{- $email = azureKeyVault "email-work" "askpt-dot" -}}
+{{- $email = azureKeyVault "email-work" -}}
 {{- end -}}
 
 {{- if stat (printf "%s/.work" (env "HOME")) -}}
@@ -29,6 +29,9 @@ data:
   work: {{ $work }}
   personal: {{ $personal }}
   hostname: {{ $hostname | quote }}
+  personal-signing-key: {{ azureKeyVault "signingkey-personal" }}
+  work-signing-key: {{ azureKeyVault "signingkey-work" }}
+  signingkey: {{ if $work }}{{ azureKeyVault "signingkey-work" }}{{ else }}{{ azureKeyVault "signingkey-personal" }}{{ end }}
 
 {{/* dont set azurekeyvault on codespaces */}}
 {{- if not $codespaces -}}

--- a/home/.chezmoi.yaml.tmpl
+++ b/home/.chezmoi.yaml.tmpl
@@ -12,6 +12,9 @@
 
 {{- $name := "André Silva" -}}
 {{- $email := "2493377+askpt@users.noreply.github.com" -}}
+{{- if and $work (not $codespaces) -}}
+{{- $email = azureKeyVault "email-work" "askpt-dot" -}}
+{{- end -}}
 
 {{- if stat (printf "%s/.work" (env "HOME")) -}}
 {{-   $work = true -}}

--- a/home/.chezmoidata/packages.yaml
+++ b/home/.chezmoidata/packages.yaml
@@ -3,47 +3,54 @@ packages:
     taps:
       - nicoverbruggen/homebrew-cask
       - azure/azd
-    brews:
-      - ansible
-      - ansible-lint
-      - azd
-      - bash
-      - bat
-      - gh
-      - git
-      - go
-      - gnupg
-      - k6
-      - grep
-      - node
-      - yarn
-      - coreutils
-      - azure-cli
-      - chezmoi
-      - python
-      - git-delta
-      - httpie
-      - sshpass
-      - git-lfs
-      - pinentry-mac
-      - powershell
-      - pkg-config
-      - colima
-      - docker
-      - docker-compose
-      - docker-buildx
-    casks:
-      - copilot-cli
-      - devtunnel
-      - gpg-suite
-      - slack
-      - visual-studio-code
-      - dotnet-sdk
-      - jetbrains-toolbox
-      - sf-symbols
-      - github-copilot-app
-      - github-copilot-for-xcode
-      - microsoft-edge
+    common:
+      brews:
+        - ansible
+        - ansible-lint
+        - azd
+        - bash
+        - bat
+        - gh
+        - git
+        - go
+        - gnupg
+        - k6
+        - grep
+        - node
+        - yarn
+        - coreutils
+        - azure-cli
+        - chezmoi
+        - python
+        - git-delta
+        - httpie
+        - sshpass
+        - git-lfs
+        - pinentry-mac
+        - powershell
+        - pkg-config
+        - colima
+        - docker
+        - docker-compose
+        - docker-buildx
+        - copilot-cli
+      casks:
+        - devtunnel
+        - gpg-suite
+        - visual-studio-code
+        - dotnet-sdk
+        - github-copilot-app
+        - microsoft-edge
+    personal:
+      brews: []
+      casks:
+        - slack
+        - jetbrains-toolbox
+        - github-copilot-for-xcode
+        - sf-symbols
+    work:
+      brews: []
+      casks: []
     fonts:
       - font-lato
       - font-open-sans
@@ -57,28 +64,37 @@ packages:
     apt:
       - zsh
       - build-essential
-    brews:
-      - ansible
-      - ansible-lint
-      - bash
-      - bat
-      - gh
-      - git
-      - gnupg
-      - go
-      - gcc
-      - grep
-      - node
-      - yarn
-      - coreutils
-      - azure-cli
-      - chezmoi
-      - python
-      - powershell
-      - git-delta
-      - httpie
-      - sshpass
-      - git-lfs
-      - copilot-cli
-      - devtunnel
-      - pkg-config
+    common:
+      brews:
+        - ansible
+        - ansible-lint
+        - bash
+        - bat
+        - gh
+        - git
+        - gnupg
+        - go
+        - gcc
+        - grep
+        - node
+        - yarn
+        - coreutils
+        - azure-cli
+        - chezmoi
+        - python
+        - powershell
+        - git-delta
+        - httpie
+        - sshpass
+        - git-lfs
+        - copilot-cli
+        - devtunnel
+        - pkg-config
+        - colima
+        - docker
+        - docker-compose
+        - docker-buildx
+    personal:
+      brews: []
+    work:
+      brews: []

--- a/home/.chezmoiscripts/darwin/run_onchange_before_20-install-packages.sh.tmpl
+++ b/home/.chezmoiscripts/darwin/run_onchange_before_20-install-packages.sh.tmpl
@@ -10,11 +10,27 @@ brew bundle --file=/dev/stdin <<EOF
 {{ range (.packages.darwin.taps | sortAlpha | uniq) -}}
 tap "{{ . }}"
 {{ end -}}
-{{ range (.packages.darwin.brews | sortAlpha | uniq) -}}
+{{ range (.packages.darwin.common.brews | sortAlpha | uniq) -}}
 brew "{{ . }}"
 {{ end -}}
-{{ range (.packages.darwin.casks | sortAlpha | uniq) -}}
+{{ range (.packages.darwin.common.casks | sortAlpha | uniq) -}}
 cask "{{ . }}"
+{{ end -}}
+{{ if .personal -}}
+{{ range (.packages.darwin.personal.brews | sortAlpha | uniq) -}}
+brew "{{ . }}"
+{{ end -}}
+{{ range (.packages.darwin.personal.casks | sortAlpha | uniq) -}}
+cask "{{ . }}"
+{{ end -}}
+{{ end -}}
+{{ if .work -}}
+{{ range (.packages.darwin.work.brews | sortAlpha | uniq) -}}
+brew "{{ . }}"
+{{ end -}}
+{{ range (.packages.darwin.work.casks | sortAlpha | uniq) -}}
+cask "{{ . }}"
+{{ end -}}
 {{ end -}}
 {{ range (.packages.darwin.fonts | sortAlpha | uniq) -}}
 cask "{{ . }}"

--- a/home/.chezmoiscripts/linux/run_onchange_before_20-install-packages.sh.tmpl
+++ b/home/.chezmoiscripts/linux/run_onchange_before_20-install-packages.sh.tmpl
@@ -9,8 +9,18 @@ echo "Update brew repositories"
 brew update
 
 brew bundle --file=/dev/stdin <<EOF
-{{ range (.packages.linux.brews | sortAlpha | uniq) -}}
+{{ range (.packages.linux.common.brews | sortAlpha | uniq) -}}
 brew "{{ . }}"
+{{ end -}}
+{{ if .personal -}}
+{{ range (.packages.linux.personal.brews | sortAlpha | uniq) -}}
+brew "{{ . }}"
+{{ end -}}
+{{ end -}}
+{{ if .work -}}
+{{ range (.packages.linux.work.brews | sortAlpha | uniq) -}}
+brew "{{ . }}"
+{{ end -}}
 {{ end -}}
 EOF
 {{ end -}}

--- a/home/.chezmoiscripts/run_once_after_30_set-file-permissions.sh.tmpl
+++ b/home/.chezmoiscripts/run_once_after_30_set-file-permissions.sh.tmpl
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Static list of files (space-separated, POSIX sh compatible)
-FILES="$HOME/.ssh/id_ed25519 $HOME/.ssh/id_rsa_homelab"
+FILES="$HOME/.ssh/id_ed25519 $HOME/.ssh/id_ed25519-emu $HOME/.ssh/id_rsa_homelab"
 
 {{ if (eq .chezmoi.os "darwin") }}
 # macOS

--- a/home/.chezmoiscripts/run_once_after_40_set-gpg-key.sh.tmpl
+++ b/home/.chezmoiscripts/run_once_after_40_set-gpg-key.sh.tmpl
@@ -1,17 +1,12 @@
 {{- if not .codespaces -}}
 #!/bin/sh
 
-# Extract the email from the GPG key
-EMAIL={{ .email }}
-# Check if the key is already imported
-if gpg --list-secret-keys "$EMAIL" >/dev/null 2>&1; then
-  echo "GPG key for $EMAIL is already imported"
-else
-  echo "Importing GPG key for $EMAIL"
-  # Import the GPG key
-  gpg --import $HOME/.gnupg/key.asc
-fi
+# Import the GPG key
+gpg --import $HOME/.gnupg/key-personal.asc
+gpg --import $HOME/.gnupg/key-work.asc
+
 # Clean up
-rm $HOME/.gnupg/key.asc
+rm $HOME/.gnupg/key-personal.asc
+rm $HOME/.gnupg/key-work.asc
 
 {{ end }}

--- a/home/dot_zprofile.tmpl
+++ b/home/dot_zprofile.tmpl
@@ -19,7 +19,9 @@ export DOTNET_ROOT=$HOME/.dotnet
 export PATH=$PATH:$DOTNET_ROOT:$DOTNET_ROOT/tools
 {{ end -}}
 {{ if eq .chezmoi.os "darwin" -}}
-export DOTNET_ROOT=/opt/homebrew/bin/.dotnet
+#export DOTNET_ROOT=/opt/homebrew/bin/.dotnet
+export DOTNET_ROOT=/usr/local/share/dotnet
+export PATH=/usr/local/share/dotnet:$PATH
 export PATH=$PATH:$DOTNET_ROOT:$DOTNET_ROOT/tools
 export PATH=$PATH:$HOME/.dotnet/tools
 {{ end -}}

--- a/home/dot_zprofile.tmpl
+++ b/home/dot_zprofile.tmpl
@@ -1,4 +1,5 @@
 # Homebrew
+export HOMEBREW_NO_UPGRADE_AUTO_UPDATES_CASKS=1
 {{ if eq .chezmoi.os "darwin" -}}
 {{   if stat "/opt/homebrew/bin/brew" -}}
 eval "$(/opt/homebrew/bin/brew shellenv)"

--- a/home/private_dot_config/git/config.tmpl
+++ b/home/private_dot_config/git/config.tmpl
@@ -228,7 +228,7 @@ useConfigOnly = true
 name={{ .name }}
 email={{ .email }}
 {{ if not .codespaces }}
-signingkey = {{ azureKeyVault "signingkey" }}
+signingkey = {{ .signingkey }}
 {{ end }}
 
 [include]
@@ -259,7 +259,6 @@ path = ~/.config/git/config.local
     colorMoved = default
 
 [init]
-
     defaultBranch = main
 
 [pretty]

--- a/home/private_dot_gnupg/key-personal.asc.tmpl
+++ b/home/private_dot_gnupg/key-personal.asc.tmpl
@@ -1,0 +1,3 @@
+{{- if not .codespaces -}}
+{{ azureKeyVault "gpg-key-personal" }}
+{{- end -}}

--- a/home/private_dot_gnupg/key-work.asc.tmpl
+++ b/home/private_dot_gnupg/key-work.asc.tmpl
@@ -1,3 +1,3 @@
 {{- if not .codespaces -}}
-{{ azureKeyVault "gpg-key" }}
+{{ azureKeyVault "gpg-key-work" }}
 {{- end -}}

--- a/home/private_dot_ssh/config.tmpl
+++ b/home/private_dot_ssh/config.tmpl
@@ -1,3 +1,8 @@
 {{- if not .codespaces -}}
+{{- if .work -}}
+{{ azureKeyVault "ssh-config-emu" }}
+{{- end -}}
+{{- else -}}
 {{ azureKeyVault "ssh-config" }}
+{{- end -}}
 {{- end -}}

--- a/home/private_dot_ssh/id_ed25519-emu.pub.tmpl
+++ b/home/private_dot_ssh/id_ed25519-emu.pub.tmpl
@@ -1,0 +1,5 @@
+{{- if not .codespaces -}}
+{{- if .work -}}
+{{ azureKeyVault "work-id-ed25519-pub-emu" }}
+{{- end -}}
+{{- end -}}

--- a/home/private_dot_ssh/id_ed25519-emu.tmpl
+++ b/home/private_dot_ssh/id_ed25519-emu.tmpl
@@ -1,0 +1,5 @@
+{{- if not .codespaces -}}
+{{- if .work -}}
+{{ azureKeyVault "work-id-ed25519-emu" }}
+{{- end -}}
+{{- end -}}


### PR DESCRIPTION
Introduce support for 'id_ed25519-emu' SSH keys and GPG keys for both work and personal environments. Update Homebrew configuration to manage packages accordingly and refactor Azure Key Vault integration for better key management. Adjust file permissions and environment variables for macOS.